### PR TITLE
Optional parameters proposed by TIM

### DIFF
--- a/code/API_definitions/number_verification.yaml
+++ b/code/API_definitions/number_verification.yaml
@@ -55,6 +55,39 @@ paths:
           description: Correlation id for the different services
           schema:
             type: string
+        ### optional parameters proposed by TIM ###
+        - name: X-Request-consentGranted
+          in: header
+          required: false
+          schema:
+            type: boolean
+          example: true
+        - name: X-Request-deviceIp
+          in: header
+          required: false
+          schema:
+            type: string
+            format: ip
+          example: 100.71.23.123
+        - name: X-Request-devicePort
+          in: header
+          required: false
+          schema:
+            type: integer
+            format: int32
+          example: 1234
+        - name: X-Request-callbackUrl
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: X-Request-returnUrl
+          in: header
+          required: false
+          schema:
+            type: string
+        ###  END OPTIONAL parameters proposed by TIM  ###
+            
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Optional parameters proposed by TIM’s Number Verification API scenario as described in GSMA document “IDY.54 Mobile Connect Verified MSISDN Definition and Technical Requirements”, as cited below:

“As an option, for the Mobile Connect Verified MSISDN service, the ID GW Authorization Server may also check the source IP address to identify that it is from the core network".