### PR TITLE
Replace polymorphism in requestBody of POST /verify

### DIFF
--- a/code/API_definitions/CAMARA/number_verification.yaml
+++ b/code/API_definitions/CAMARA/number_verification.yaml
@@ -59,7 +59,7 @@ paths:
         - Phone number verify
       summary: Verifies if the received hashed/plain text phone number matches the phone number associated with the access token
       description: |
-        Verifies if the specified phone number (plain text or hashed format) matches the one that the user is currently using.
+        Verifies if the specified phone number (either in plain text or hashed format) matches the one that the user is currently using. Only one of the plain or hashed formats must be provided.
          - The number verification will be done for the user that has authenticated via mobile network and so their `sub` is in the access token
          - It returns true/false depending on if the hashed phone number received as input matches the authenticated user's `device phone number` associated to the access token
       operationId: phoneNumberVerify
@@ -155,20 +155,14 @@ components:
   schemas:
     NumberVerificationRequestBody:
       type: object
-      description: Payload to verify the phone number
-      oneOf:
-          - $ref: '#/components/schemas/PhoneNumber'
-          - $ref: '#/components/schemas/HashedPhoneNumber'
-    PhoneNumber:
-      type: object
+      description: Payload to verify the phone number.
+      minProperties: 1
+      maxProperties: 1
       properties:
         phoneNumber:
           description: A phone number belonging to the user in **E.164 format (starting with country code)**. Optionally prefixed with '+'.
           type: string
           example: '+346661113334'
-    HashedPhoneNumber:
-      type: object
-      properties:
         hashedPhoneNumber:
           description: Hashed phone number. SHA-256 (in hexadecimal representation) of the mobile phone number in **E.164 format (starting with country code)**. Optionally prefixed with '+'.
           type: string


### PR DESCRIPTION
#### What type of PR is this?

* correction


#### What this PR does / why we need it:

To simplify the requestBody and avoid usage of polymorphism (oneOf), which causes problems when mapped to certain code languages. Functionality is kept the same way, only that now oneOf is enforced by means of min/maxProperties. This solution is valid for this case as one and only one property is required.

#### Which issue(s) this PR fixes:

Fixes #48 

#### Special notes for reviewers:

Discussed previously in the issue

#### Changelog input

```
* requestBody of phoneNumberVerify redesigned to avoid usage of oneOf

```

