### PR TITLE
Fixed x-correlator typo (changed to X-Correlator)

### DIFF
--- a/code/API_definitions/number_verification.yaml
+++ b/code/API_definitions/number_verification.yaml
@@ -67,7 +67,7 @@ paths:
       operationId: phoneNumberVerify
       parameters:
         - in: header
-          name: x-correlator
+          name: X-Correlator
           required: false
           description: Correlation id for the different services
           schema:
@@ -82,7 +82,7 @@ paths:
         '200':
           description: OK
           headers:
-            x-correlator:
+            X-Correlator:
               description: Correlation id for the different services
               schema:
                 type: string
@@ -117,7 +117,7 @@ paths:
       operationId: phoneNumberShare
       parameters:
         - in: header
-          name: x-correlator
+          name: X-Correlator
           required: false
           description: Correlation id for the different services
           schema:
@@ -126,7 +126,7 @@ paths:
         '200':
           description: OK
           headers:
-            x-correlator:
+            X-Correlator:
               description: Correlation id for the different services
               schema:
                 type: string
@@ -212,7 +212,7 @@ components:
     Generic400:
       description: Problem with the client request
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string
@@ -227,7 +227,7 @@ components:
     Generic401:
       description: Authentication problem with the client request
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string
@@ -246,7 +246,7 @@ components:
           - Client authentication was not via mobile network. In order to check the authentication method, AMR parameter value in the 3-legged user's access token can be used and make sure that the authentication was not either by SMS+OTP nor username/password (`{"code": "NUMBER_VERIFICATION.USER_NOT_AUTHENTICATED_BY_MOBILE_NETWORK","message": "Client must authenticate via the mobile network to use this service"}`)
           - Phone number cannot be deducted from access token context.(`{"code": "NUMBER_VERIFICATION.INVALID_TOKEN_CONTEXT","message": "Phone number cannot be deducted from access token context"}`)
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string
@@ -273,7 +273,7 @@ components:
     Generic500:
       description: Server error
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string
@@ -288,7 +288,7 @@ components:
     Generic503:
       description: Service unavailable. Typically the server is down.
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string
@@ -303,7 +303,7 @@ components:
     Generic504:
       description: Request time exceeded. If it happens repeatedly, consider reducing the request complexity
       headers:
-        x-correlator:
+        X-Correlator:
           description: Correlation id for the different services
           schema:
             type: string


### PR DESCRIPTION
Fixed accordingly to the design guideline: 
`x-correlator` to `X-Correlator`


#### What type of PR is this?

Add one of the following kinds:
bug


#### What this PR does / why we need it:

Fixed accordingly to the design guideline: 
`x-correlator` to `X-Correlator`


#### Which issue(s) this PR fixes:



#### Special notes for reviewers:



#### Changelog input

```
- Fixed accordingly to the design guideline:  `x-correlator` to `X-Correlator`

```

#### Additional documentation 

This section can be blank.



```
docs

```
