### PR TITLE
update codeowners from Telefónica

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @DT-DawidWroblewski @bigludo7
+* @DT-DawidWroblewski @bigludo7 @fernandopradocabrillo

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -3,4 +3,5 @@
 | Deutsche Telekom AG | Dawid Wróblewski |
 | KDDI | Toshiyasu Wakayama |
 | Telefónica | José Luis Urien |
+| Telefónica | Fernando Prado Cabrillo |
 | Orange | Ludovic Robert |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:
Include @fernandopradocabrillo from Telefónica as codeowner



#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

N/A

#### Changelog input

N/A

#### Additional documentation 

N/A