### PR TITLE
feat: move basePath into "url" of "servers"-section

### DIFF
--- a/code/API_definitions/number_verification.yaml
+++ b/code/API_definitions/number_verification.yaml
@@ -49,14 +49,11 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: https://{host}{basePath}
+  - url: '{apiRoot}/number-verification/v0'
     variables:
-      host:
-        default: api.example.com
-        description: Host that serves the API
-      basePath:
-        default: /number-verification/v0
-        description: Base path for the number verification API
+      apiRoot:
+        default: http://localhost:9091
+        description: API root
 tags:
   - name: Phone number verify
     description: API operation to verify a phone number received as input. It can be received either in plain text or hashed format.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction
* enhancement/feature

#### What this PR does / why we need it:
Remove the basepath and move this to the "url"-property.
Setting the host default to "http://localhost:9091" to align with other CAMARA specifications.



#### Which issue(s) this PR fixes:

Fixes #77 