### PR TITLE
Use valid Wiki-reference for meeting-minutes

### DIFF
--- a/documentation/MeetingMinutes/README.MD
+++ b/documentation/MeetingMinutes/README.MD
@@ -1,3 +1,3 @@
 ## RELEVANT INFORMATION
 
-Since April 4th 2024 WG meeting minutes are placed in [Number Verification Wiki Confluence site](https://wiki.camaraproject.org/display/CAM/Number+Verification)
+Since April 4th 2024 WG meeting minutes are placed in [Number Verification Wiki Confluence site](https://wiki.camaraproject.org/display/CAM/NumberVerification)


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug


#### What this PR does / why we need it:
Uses the valid URL to the camara-wiki-page of NumberVerification.


#### Which issue(s) this PR fixes:

Fixes [#114](https://github.com/camaraproject/NumberVerification/issues/114)
