### PR TITLE
Release of API version 1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,4 +69,20 @@ This version contains significant changes compared to v0.3.1, and it is not back
 - @maxl2287 made their first contribution by adding a pattern for PhoneNumber in /verify  [PR68](https://github.com/camaraproject/NumberVerification/issues/76)
 - @bigludo7 made their first contribution by making change following megalinter integration [PR103](https://github.com/camaraproject/NumberVerification/pull/103)
 
+**Full Changelog**: https://github.com/camaraproject/NumberVerification/compare/v0.3.1...r1.1
 
+## v0.3.1
+
+Initital release of Camara Number Verification API
+
+## What's Changed
+* Telefonica Proposal by @monamok in https://github.com/camaraproject/NumberVerification/pull/3
+* Adding API documentation by @monamok in https://github.com/camaraproject/NumberVerification/pull/6
+* Initial content for Number Verify by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/2
+* New specific 403 token error and guidelines alignment by @monamok in https://github.com/camaraproject/NumberVerification/pull/19
+* adding puml by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/24
+* guidelines alignment errors and camel case by @monamok in https://github.com/camaraproject/NumberVerification/pull/30
+* Change 'sub' cardinality + add attribute description by @bigludo7 in https://github.com/camaraproject/NumberVerification/pull/32
+* Embed documentation in API Spec by @monamok in https://github.com/camaraproject/NumberVerification/pull/38
+
+**Full Changelog**: https://github.com/camaraproject/NumberVerification/commits/v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,18 @@ Initital release of Camara Number Verification API
 * Telefonica Proposal by @monamok in https://github.com/camaraproject/NumberVerification/pull/3
 * Adding API documentation by @monamok in https://github.com/camaraproject/NumberVerification/pull/6
 * Initial content for Number Verify by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/2
+* main readme update by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/12
+* reshaping the content (+readme.md update) by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/13
+* fixing links by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/14
+* fixing links by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/15
 * New specific 403 token error and guidelines alignment by @monamok in https://github.com/camaraproject/NumberVerification/pull/19
+* repo fine tunining by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/23
+* Repo fine tuning recovery by @monamok in https://github.com/camaraproject/NumberVerification/pull/22
 * adding puml by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/24
 * guidelines alignment errors and camel case by @monamok in https://github.com/camaraproject/NumberVerification/pull/30
+* updating content insde readme.md by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/34
 * Change 'sub' cardinality + add attribute description by @bigludo7 in https://github.com/camaraproject/NumberVerification/pull/32
+* Adding PR and Issues commonalities templates by @monamok in https://github.com/camaraproject/NumberVerification/pull/40
 * Embed documentation in API Spec by @monamok in https://github.com/camaraproject/NumberVerification/pull/38
 
 **Full Changelog**: https://github.com/camaraproject/NumberVerification/commits/v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,10 @@ The API definition(s) are based on
 **number-verification 1.0.0-rc.1** is the first release-candidate version for the v1.0.0 of the number verification API.
 
 - API definition **with inline documentation**:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
-  - 
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml)
+    
 **number-verification 1.0.0-rc.1 is the first stable version for CAMARA Number Verification API**
 
 This version contains significant changes compared to v0.3.1, and it is not backward compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Table of contents
 
 - **[r1.1](#r11)**
+- [v0.3.1](#v031)
 
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,71 @@
-# Changelog
+# Changelog Number Verification API
 
-## v0.4.0-wip [Work in Progress]
 
-## Please note:
+## Table of contents
 
-- This is *work-in-progress* version, it should be considered as a draft
-- There are bug fixes to be expected and incompatible changes in upcoming versions 
-- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments
-- Version numbers before v0.4.0-wip were used during the development of this version but not released
+- **[r1.1](#r11)**
+
+
+**Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+
+
+# r1.1 - rc
+
+## Release Notes
+
+This release contains the definition and documentation of
+* Number Verification API 1.0.0-rc.1
+
+
+
+The API definition(s) are based on
+* Commonalities v0.4.0
+* Identity and Consent Management v0.2.0
+
+
+## Number Verification v1.0.0-rc.1
+
+
+**number-verification 1.0.0-rc.1** is the first release-candidate version for the v1.0.0 of the number verification API.
+
+- API definition **with inline documentation**:
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
+  - 
+**number-verification 1.0.0-rc.1 is the first stable version for CAMARA Number Verification API**
+
+This version contains significant changes compared to v0.3.1, and it is not backward compatible.
 
 ### Added
 
-- Merge pull request #58 from fernandopradocabrillo/update-documentation-and-remove-deprecated-files
-- include documentation inside yaml file, remove deprecated files and fix image link
-- Merge pull request #57 from fernandopradocabrillo/update-tef-codeowners
-- update codeowners from Telefónica
-- Merge pull request #56 from camaraproject/bigludo7-patch-1
-- Merge pull request #58 from fernandopradocabrillo/update-documentation-and-remove-deprecated-files
-- include documentation inside yaml file, remove deprecated files and fix image link
-- Merge pull request #57 from fernandopradocabrillo/update-tef-codeowners
-- update codeowners from Telefónica
-- Merge pull request #56 from camaraproject/bigludo7-patch-1
-- Update number_verification.yaml
-- Merge pull request #53 from DT-DawidWroblewski/main
-- update to yaml
-- Merge branch 'main' of https://github.com/DT-DawidWroblewski/NumberVerification
-- adding fixes to PR
-- Merge pull request #52 from jlurien/chore/replace-polymorphism-requestBody
-- Replace polymorphism in requestBody of POST /verify
-- Update documentation/API_documentation/README.MD
-- Merge pull request #50 from monamok/chore/update_documentation
-- cleaning repo
-- Relevant definition section added
-- Merge pull request #43 from monamok/chore/phone_number_description_alignment
-- error code copy/pase typo removed
-- updating uml url
-- phoneNumber descriptions aligned to the other APIs
+* User Story in documentation/API_documentation directory by @bigludo7 [PR118](https://github.com/camaraproject/NumberVerification/pull/118)
+* Test Definition in Test_Definitions directory [To be done]
 
 ### Changed
 
-* N/A
+* Aligned with CAMARA design guidelines & Identity Consent management
+* Make the '+' mandatory for the phone number by @fernandopradocabrillo [PR90](https://github.com/camaraproject/NumberVerification/pull/90)
+* Cosmetic change following megalinter integration by @bigludo7 [PR103](https://github.com/camaraproject/NumberVerification/pull/103)
+* Update Authorization and authentication part accordingly to ICM by @fernandopradocabrillo [PR88](https://github.com/camaraproject/NumberVerification/issues/88)
+* Adding a pattern for PhoneNumber in /verify by @maxl2287 [PR68](https://github.com/camaraproject/NumberVerification/issues/76)
+* Clarify use of 'user' and 'subscriber' wording by @AxelNennker [PR102](https://github.com/camaraproject/NumberVerification/pull/102)
 
 ### Fixed
 
-* N/A
+* Replaced OAuth2 auth code flow by OIDC auth code flow by @AxelNennker [PR109](https://github.com/camaraproject/NumberVerification/pull/109)
 
 ### Removed
 
-* N/A
+* n/a
+
+## New Contributors 
+
+- @AxelNennker made their first contribution in clarifying use of 'user' and 'subscriber' wording by @AxelNennker [PR102](https://github.com/camaraproject/NumberVerification/pull/102)
+- @rartych made their first contribution in GitHub workflows [#108](https://github.com/camaraproject/NumberVerification/pull/108)
+- @fernandopradocabrillo made their first contribution by updating Authorization and authentication part accordingly to ICM [PR88](https://github.com/camaraproject/NumberVerification/issues/88)
+- @maxl2287 made their first contribution by adding a pattern for PhoneNumber in /verify  [PR68](https://github.com/camaraproject/NumberVerification/issues/76)
+- @bigludo7 made their first contribution by making change following megalinter integration [PR103](https://github.com/camaraproject/NumberVerification/pull/103)
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,18 +79,10 @@ Initital release of Camara Number Verification API
 * Telefonica Proposal by @monamok in https://github.com/camaraproject/NumberVerification/pull/3
 * Adding API documentation by @monamok in https://github.com/camaraproject/NumberVerification/pull/6
 * Initial content for Number Verify by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/2
-* main readme update by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/12
-* reshaping the content (+readme.md update) by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/13
-* fixing links by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/14
-* fixing links by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/15
 * New specific 403 token error and guidelines alignment by @monamok in https://github.com/camaraproject/NumberVerification/pull/19
-* repo fine tunining by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/23
-* Repo fine tuning recovery by @monamok in https://github.com/camaraproject/NumberVerification/pull/22
 * adding puml by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/24
 * guidelines alignment errors and camel case by @monamok in https://github.com/camaraproject/NumberVerification/pull/30
-* updating content insde readme.md by @DT-DawidWroblewski in https://github.com/camaraproject/NumberVerification/pull/34
 * Change 'sub' cardinality + add attribute description by @bigludo7 in https://github.com/camaraproject/NumberVerification/pull/32
-* Adding PR and Issues commonalities templates by @monamok in https://github.com/camaraproject/NumberVerification/pull/40
 * Embed documentation in API Spec by @monamok in https://github.com/camaraproject/NumberVerification/pull/38
 
 **Full Changelog**: https://github.com/camaraproject/NumberVerification/commits/v0.3.1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Repository to describe, develop, document and test the NumberVerification API fa
 ## Status and released versions
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* **The latest available release and version of CAMARA Number Verification API is 1.0.0-rc.1 This is the first stable version candidate of the API**. It is suitable for implementors and could be use with customers in productive environments.
+* **The latest pre-release of CAMARA Number Verification API is 1.0.0-rc.1 This is the release candidate of the first stable version of the API**. It is suitable for implementors.
 * The Release Tag is [r1.1](https://github.com/camaraproject/NumberVerification/releases/tag/r1.1).
   - API definition **with inline documentation**:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml)

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Repository to describe, develop, document and test the NumberVerification API fa
 ## Status and released versions
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* **The latest available release and version of CAMARA OTPValidaton API is 1.0.0-rc.1 This is the first stable version candidate of the API**. It is suitable for implementors and could be use with customers in productive environments.
-* Release 1.0.0 of the API is available within the [release-1.0.0 branch](https://github.com/camaraproject/NumberVerification/tree/release-1.0.0):
+* **The latest available release and version of CAMARA Number Verification API is 1.0.0-rc.1 This is the first stable version candidate of the API**. It is suitable for implementors and could be use with customers in productive environments.
+* The Release Tag is [r1.1](https://github.com/camaraproject/NumberVerification/releases/tag/r1.1).
   - API definition **with inline documentation**:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/r1.1/code/API_definitions/number_verification.yaml)
 
 
 * The previous version 0.3.1 is available within the [release-0.3.1 branch](https://github.com/camaraproject/NumberVerification/tree/release-0.3.1):

--- a/README.md
+++ b/README.md
@@ -20,17 +20,22 @@ Repository to describe, develop, document and test the NumberVerification API fa
 
 ## Meetings
 
-* Meetings are held virtually in Zoom
-* Current schedule & meeting links: [Meetings information](documentation/MeetingMinutes/README.MD)
+* Current schedule, registration, & meeting links are available on the confluence page: [Meetings information](https://wiki.camaraproject.org/display/CAM/NumberVerification)
 
-## Results
-* Sub Project is in progress
+
 
 ## Status and released versions
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* **The latest available release and version of CAMARA NumberVerification API is 0.3.1. This is the first alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-* Release 0.3.1 of the API is available within the [release-0.3.1 branch](https://github.com/camaraproject/NumberVerification/tree/release-0.3.1):
+* **The latest available release and version of CAMARA OTPValidaton API is 1.0.0-rc.1 This is the first stable version candidate of the API**. It is suitable for implementors and could be use with customers in productive environments.
+* Release 1.0.0 of the API is available within the [release-1.0.0 branch](https://github.com/camaraproject/NumberVerification/tree/release-1.0.0):
+  - API definition **with inline documentation**:
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/blob/release-1.0.0/code/API_definitions/number_verification.yaml)
+
+
+* The previous version 0.3.1 is available within the [release-0.3.1 branch](https://github.com/camaraproject/NumberVerification/tree/release-0.3.1):
   - API definition **with inline documentation**:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberVerification/blob/release-0.3.1/code/API_definitions/CAMARA/number_verification.yaml)
     - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberVerification/release-0.3.1/code/API_definitions/CAMARA/number_verification.yaml&nocors)
@@ -41,3 +46,8 @@ Repository to describe, develop, document and test the NumberVerification API fa
 
 * To subscribe / unsubscribe to the mailing list of this Sub Project and thus be / resign as Contributor please visit <https://lists.camaraproject.org/g/sp-nve>.
 * A message to all Contributors of this Sub Project can be sent using <sp-nve@lists.camaraproject.org>.
+
+
+## Relevant Information
+
+Since April 4th 2024 WG meeting minutes are placed in [Number Verification Wiki Confluence site](https://wiki.camaraproject.org/display/CAM/Number+Verification)

--- a/code/API_definitions/number_verification.yaml
+++ b/code/API_definitions/number_verification.yaml
@@ -48,7 +48,7 @@ info:
 
     # Further info and support
     [GSMA Mobile Connect Verified MSISDN specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.54-Mobile-Connect-Verified-MSISDN-Definition-and-Technical-Requirements-1.0.pdf) was used as source of input for this API.  For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
-  version: wip
+  version: 1.0.0-rc.1
   termsOfService: http://example.com/terms/
   contact:
     name: API Support

--- a/code/API_definitions/number_verification.yaml
+++ b/code/API_definitions/number_verification.yaml
@@ -49,20 +49,16 @@ info:
     # Further info and support
     [GSMA Mobile Connect Verified MSISDN specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.54-Mobile-Connect-Verified-MSISDN-Definition-and-Technical-Requirements-1.0.pdf) was used as source of input for this API.  For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
   version: 1.0.0-rc.1
-  termsOfService: http://example.com/terms/
-  contact:
-    name: API Support
-    url: http://www.example.com/support
-    email: support@example.com
+  x-camara-commonalities: 0.4.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: '{apiRoot}/number-verification/v0'
+  - url: '{apiRoot}/number-verification/v1rc1'
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath
 tags:
   - name: Phone number verify
     description: API operation to verify a phone number received as input. It can be received either in plain text or hashed format.

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -16,7 +16,8 @@ Checklist for number_verification in version b1.0.0-rc1.1
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   | link |
 |  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   | link |
 | 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   N   | [PR121](https://github.com/camaraproject/NumberVerification/pull/121) |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   N   | [link](/CHANGELOG.md) |
+
 | 12 | Previous public-release was certified        |   O   |         O         |    O    |    M   |   Y   |      |
 
 

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -5,19 +5,16 @@ Checklist for number_verification in version b1.0.0-rc1.1
 | Nr | API release assets  | alpha | release-candidate |  public-release<br>initial | public-release<br> stable | Status | Comments |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [link](/code/API_definitions/number_verification.yaml) |
-
 |  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y    |      |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |      |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | Embed documentation into API spec - [link](/code/API_definitions/number_verification.yaml)  |
-
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |   N   | [PR118](https://github.com/camaraproject/NumberVerification/pull/118) |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |   N   | [link](documentation/API_documentation/) |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   N   | link |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   | link |
 |  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   | link |
 | 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
 | 11 | Change log updated                           |   M   |         M         |    M    |    M   |   N   | [link](/CHANGELOG.md) |
-
 | 12 | Previous public-release was certified        |   O   |         O         |    O    |    M   |   Y   |      |
 
 

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -1,0 +1,25 @@
+# API Readiness Checklist
+
+Checklist for number_verification in version b1.0.0-rc1.1
+
+| Nr | API release assets  | alpha | release-candidate |  public-release<br>initial | public-release<br> stable | Status | Comments |
+|----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
+|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [link](https://github.com/camaraproject/NumberVerification/blob/main/code/API_definitions/number_verification.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y    |      |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |      |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | Embed documentation into API spec - [link](https://github.com/camaraproject/NumberVerification/blob/main/code/API_definitions/number_verification.yaml)  |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |   N   | [PR118](https://github.com/camaraproject/NumberVerification/pull/118) |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   N   | link |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   | link |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   | link |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   N   | [PR121](https://github.com/camaraproject/NumberVerification/pull/121) |
+| 12 | Previous public-release was certified        |   O   |         O         |    O    |    M   |   Y   |      |
+
+
+
+
+Note: It is normal that the checklists of the (final) release-candidate and its subsequent public-release are the same, while additional release assets are required for a subsequent stable public-release.
+
+The documentation for the content of the checklist is here: [API Readiness Checklist documentation](https://wiki.camaraproject.org/x/AgAVAQ#APIReleaseProcess-APIreadinesschecklist)

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -9,7 +9,8 @@ Checklist for number_verification in version b1.0.0-rc1.1
 |  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y    |      |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |      |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | Embed documentation into API spec - [link](https://github.com/camaraproject/NumberVerification/blob/main/code/API_definitions/number_verification.yaml)  |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | Embed documentation into API spec - [link](/code/API_definitions/number_verification.yaml)  |
+
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |   N   | [PR118](https://github.com/camaraproject/NumberVerification/pull/118) |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   N   | link |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   | link |

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API Readiness Checklist
 
-Checklist for number_verification in version b1.0.0-rc1.1
+Checklist for number_verification 1.0.0-rc.1 in release r1.1
 
 | Nr | API release assets  | alpha | release-candidate |  public-release<br>initial | public-release<br> stable | Status | Comments |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|

--- a/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
+++ b/documentation/API_documentation/NumberVerification-Readiness-Checklist.md
@@ -4,7 +4,8 @@ Checklist for number_verification in version b1.0.0-rc1.1
 
 | Nr | API release assets  | alpha | release-candidate |  public-release<br>initial | public-release<br> stable | Status | Comments |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [link](https://github.com/camaraproject/NumberVerification/blob/main/code/API_definitions/number_verification.yaml) |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [link](/code/API_definitions/number_verification.yaml) |
+
 |  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y    |      |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |      |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation
* subproject management



#### What this PR does / why we need it:

Generation of first release-candidate for NumberVerification API

This first release candidate r1.1 contains the definition and documentation of the release-candidate of the NumberVerification API v1.0.0-rc.1.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
