### PR TITLE
NumberVerification over WiFi

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -64,7 +64,7 @@ info:
 
     # Authorization and authentication
 
-    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to [Identity and Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -32,7 +32,7 @@ info:
     ## Authentication Request without a temporary token
 
     If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in the current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
-    This mechanism of utilizing the mobile connection does not work on a fixed-net Internet connection nor over WiFi or VPN.
+    For this method of authentication to work, the device must be connected to the mobile network.
     The API Consumer should not send a login_hint in the Authentication Request.
 
     # Resources and Operations overview

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -23,11 +23,15 @@ info:
 
     # The Authentication Request
 
+    ## Authentication Request with a temporary token
+
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.
     How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
-    When the API Consumer sends the Authentication Request, the temporary token is send in the login_hint parameter with the prefix "operatortoken:".
+    The API Consumer sends the temporary token to their backend and which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
 
-    If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
+    ## Authentication Request without a temporary token
+    
+    If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in the current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
     This mechanism of utilizing the mobile connection does not work on a fixed-net Internet connection nor over WiFi or VPN.
     The API Consumer should not send a login_hint in the Authentication Request.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -72,7 +72,7 @@ info:
 
     In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
-  version: 1.1.0-rc.2
+  version: 2.0-rc1
   x-camara-commonalities: 0.5
   license:
     name: Apache 2.0

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -57,7 +57,7 @@ info:
 
       The API Provider implies the request parameter prompt=none in the Authication Request for this API.
 
-      The lifetime of the access token SHOULD very short.
+      The lifetime of the access token SHOULD be very short.
       
     - **(2):** The way in which the phone_number is retrieved depends on the implementation. 
       For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number. 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -14,13 +14,13 @@ info:
 
     # Relevant Definitions and Concepts
 
-    - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection. 
+    - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
 
     # API Functionality
 
     This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service
-    
+
     # The Authentication Request
 
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi.
@@ -30,18 +30,18 @@ info:
     If the API Consumer does not have a TS.43 temporary token then the IP address of the mobile connection is used to identify the mobile subscription.
     This mechanism of resolving an IP address to a subscribtion does not work on a fixed-net Internet connection nor over WiFi.
     The API Consumer should not send a login_hint in the Authentication Request.
-    
+
     # Resources and Operations overview
 
     This API currently provides two endpoints which both require a **3-legged token**:
-    - The first one checks if the user's mobile phone number matches the phone number associated with the mobile device. 
+    - The first one checks if the user's mobile phone number matches the phone number associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.
     - The next one retrieves the phone number associated to the access token and returns it.
 
     # Sequence Diagram
-    
-    Number Verification API uses the **standard [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)**. 
+
+    Number Verification API uses the **standard [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)**.
     The following diagram will help to clarify the end-to-end process, including steps prior to this API call.
 
     Note that the diagram shows just an example of a direct integration from developer's application and the API Provider's Authorization Server and API.
@@ -50,15 +50,15 @@ info:
 
     **Implementation Details:**
 
-    - **(1):** Authentication must be automatic without any user interactions. 
-      Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App. 
-      
+    - **(1):** Authentication must be automatic without any user interactions.
+      Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
+  
       The API Consumer should use of the request parameter prompt=none in the Authication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
 
       The API Provider implies the request parameter prompt=none in the Authication Request for this API.
 
       The lifetime of the access token SHOULD be very short.
-      
+
     - **(2):** The way in which the phone_number is retrieved depends on the implementation. 
       For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number. 
       Some other implementations might request the phone_number associated to the token from Authorization Server.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -8,7 +8,7 @@ info:
 
     # Introduction
 
-    Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service.
+    Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service, either by getting the comparison result or receiving the phone number of the device that it is used, so they can verify it themselves.
 
     The mobile phone number is personal data and end-user consent might be required.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -30,7 +30,7 @@ info:
     The API Consumer sends the temporary token to their backend and which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
 
     ## Authentication Request without a temporary token
-    
+
     If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in the current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
     This mechanism of utilizing the mobile connection does not work on a fixed-net Internet connection nor over WiFi or VPN.
     The API Consumer should not send a login_hint in the Authentication Request.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -23,7 +23,7 @@ info:
 
     # The Authentication Request
 
-    If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi.
+    If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.
     How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
     When the API Consumer sends the Authentication Request, the temporary token is send in the login_hint parameter with the prefix "operatortoken:".
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -37,7 +37,7 @@ info:
 
     # Resources and Operations overview
 
-    This API currently provides two endpoints which both require a **3-legged token** obtained by using one of the two methods indicated in _The Authentication Request_ section (therefore **excluding** for example by SMS/OTP or user/password as an authentication method):
+    This API currently provides two endpoints which both require a **3-legged token** obtained by using one of the two methods indicated in _The Authentication Request_ section. This therefore **excludes** using, for example, SMS/OTP or user/password as an authentication method:
     - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches the one actually associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -17,7 +17,7 @@ info:
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device. This mechanism relies on temporary tokens provided by the operator, as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
-    
+
     # API Functionality
 
     This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -83,7 +83,7 @@ externalDocs:
   description: Project documentation at CAMARA
   url: https://github.com/camaraproject/NumberVerification
 servers:
-  - url: '{apiRoot}/number-verification/v1'
+  - url: '{apiRoot}/number-verification/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -3,7 +3,7 @@ info:
   title: Number Verification
   description: |
     API to verify or retrieve the **mobile phone number** that is currently used on the user's device
-  
+
     In this API **phone number** refers to the mobile phone number.
 
     # Introduction

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -27,7 +27,7 @@ info:
     How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
     When the API Consumer sends the Authentication Request, the temporary token is send in the login_hint parameter with the prefix "operatortoken:".
 
-    If the API Consumer does not have a TS.43 temporary token then the IP address of the mobile connection is used to identify the mobile subscription.
+    If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
     This mechanism of resolving an IP address to a subscribtion does not work on a fixed-net Internet connection nor over WiFi.
     The API Consumer should not send a login_hint in the Authentication Request.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -27,8 +27,8 @@ info:
     ## Authentication Request with a temporary token
 
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.
-    How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
     The API Consumer sends the temporary token to their backend which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
+    How the API Consumers get a TS.43 temporary token and how this token is sent to their backend, is out-of-scope of the API definition.
 
     ## Authentication Request without a temporary token
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -10,8 +10,6 @@ info:
 
     Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service, either by getting the comparison result or receiving the phone number of the device that it is used, so they can verify it themselves.
 
-    The mobile phone number is personal data and end-user consent might be required.
-
     # Relevant Definitions and Concepts
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -28,7 +28,7 @@ info:
 
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.
     How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
-    The API Consumer sends the temporary token to their backend and which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
+    The API Consumer sends the temporary token to their backend which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
 
     ## Authentication Request without a temporary token
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -14,7 +14,7 @@ info:
 
     # Relevant Definitions and Concepts
 
-    - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
+    - **Network-Based Authentication**: Authentication mechanism based on the identification of the mobile phone.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device. This mechanism relies on temporary tokens provided by the operator, as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -54,9 +54,9 @@ info:
     - **(1):** Authentication must be automatic without any user interactions.
       Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
 
-      The API Consumer should use of the request parameter prompt=none in the Authication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
+      The API Consumer should use of the request parameter prompt=none in the Authentication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
 
-      The API Provider implies the request parameter prompt=none in the Authication Request for this API.
+      The API Provider implies the request parameter prompt=none in the Authentication Request for this API.
 
     - **(2):** The way in which the phone_number is retrieved depends on the implementation.
       For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -8,9 +8,9 @@ info:
 
     # Introduction
 
-The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the network, returning "true" or false, or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.```
+    The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the network, returning "true" or false, or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.```
 
-    It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither OTPs (One-time passwords) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM (Subscriber Identity Module) is not spoofed or cloned.
+    It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither one-time passwords (OTP) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM is not spoofed or cloned.
 
     # Relevant Definitions and Concepts
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -16,7 +16,7 @@ info:
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
-
+    - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device.
     # API Functionality
 
     This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -34,7 +34,7 @@ info:
 
     If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in the current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
     For this method of authentication to work, the device must be connected to the mobile network.
-    The API Consumer should not send a login_hint in the Authentication Request.
+    If the API Consumer does not have a TS.43 temporary token then the API Consumer should not send a login_hint in the Authentication Request.
 
     # Resources and Operations overview
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -52,15 +52,15 @@ info:
 
     - **(1):** Authentication must be automatic without any user interactions.
       Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
-  
+
       The API Consumer should use of the request parameter prompt=none in the Authication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
 
       The API Provider implies the request parameter prompt=none in the Authication Request for this API.
 
       The lifetime of the access token SHOULD be very short.
 
-    - **(2):** The way in which the phone_number is retrieved depends on the implementation. 
-      For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number. 
+    - **(2):** The way in which the phone_number is retrieved depends on the implementation.
+      For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number.
       Some other implementations might request the phone_number associated to the token from Authorization Server.
 
     # Authorization and authentication

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -34,7 +34,6 @@ info:
 
     If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in the current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
     For this method of authentication to work, the device must be connected to the mobile network.
-    If the API Consumer does not have a TS.43 temporary token then the API Consumer should not send a login_hint in the Authentication Request.
 
     # Resources and Operations overview
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -73,7 +73,7 @@ info:
 
     In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
-  version: 2.0-rc1
+  version: wip
   x-camara-commonalities: 0.5
   license:
     name: Apache 2.0

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -15,7 +15,7 @@ info:
     # Relevant Definitions and Concepts
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the mobile phone.
-    Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
+    A network operator knows to which subscriber a connected mobile phone belongs and what its associated phone number is. 
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device. This mechanism relies on temporary tokens provided by the operator, as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
 
     # API Functionality

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -39,7 +39,7 @@ info:
     # Resources and Operations overview
 
     This API currently provides two endpoints which both require a **3-legged token**:
-    - The first one checks if the user's mobile phone number matches the phone number associated with the mobile device.
+    - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches that actually associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.
     - The next one retrieves the phone number associated to the access token and returns it.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -58,9 +58,9 @@ info:
 
       The API Provider implies the request parameter prompt=none in the Authentication Request for this API.
 
-    - **(2):** The way in which the phone_number is retrieved depends on the implementation.
-      For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number.
-      Some other implementations might request the phone_number associated to the token from Authorization Server.
+    - **(2):** The way in which the phone number is retrieved depends upon the implementation.
+      For example, the access token may be a self-contained encrypted JWT, and so the API provider can decrypt and identify phone number directly from the access token.
+      Other implementations might retrieve the phone number associated with the access token from their Authorization Server.
 
     # Authorization and authentication
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -16,7 +16,7 @@ info:
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
-    - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device.
+    - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device. This mechanism relies on temporary tokens provided by the operator, as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
     
     # API Functionality
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -58,8 +58,6 @@ info:
 
       The API Provider implies the request parameter prompt=none in the Authication Request for this API.
 
-      The lifetime of the access token SHOULD be very short.
-
     - **(2):** The way in which the phone_number is retrieved depends on the implementation.
       For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number.
       Some other implementations might request the phone_number associated to the token from Authorization Server.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -72,8 +72,6 @@ info:
 
     In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
-    # Further info
-    [GSMA Mobile Connect Verified MSISDN specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.54-Mobile-Connect-Verified-MSISDN-Definition-and-Technical-Requirements-1.0.pdf) was used as source of input for this API.
   version: wip
   x-camara-commonalities: 0.5
   license:

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -17,6 +17,7 @@ info:
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.
     Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device.
+    
     # API Functionality
 
     This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -38,7 +38,7 @@ info:
     # Resources and Operations overview
 
     This API currently provides two endpoints which both require a **3-legged token** obtained by using one of the two methods indicated in _The Authentication Request_ section (therefore **excluding** for example by SMS/OTP or user/password as an authentication method):
-    - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches that actually associated with the mobile device.
+    - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches the one actually associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.
     - The /device-phone-number endpoint returns the phone number associated by the network operator with the SIM in the end user's device.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -42,7 +42,7 @@ info:
     - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches that actually associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.
-    - The next one retrieves the phone number associated to the access token and returns it.
+    - The /device-phone-number endpoint returns the phone number associated by the network operator with the SIM in the end user's device.
 
     # Sequence Diagram
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -8,7 +8,7 @@ info:
 
     # Introduction
 
-    Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service, either by getting the comparison result or receiving the phone number of the device that it is used, so they can verify it themselves.
+The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the network, returning "true" or false, or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.```
 
     It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither OTPs (One-time passwords) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM (Subscriber Identity Module) is not spoofed or cloned.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -28,7 +28,7 @@ info:
     When the API Consumer sends the Authentication Request, the temporary token is send in the login_hint parameter with the prefix "operatortoken:".
 
     If the API Consumer does not have a TS.43 temporary token then the API Consumer must use OpenId Connect Authorization Code Flow as described in current release of [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement).
-    This mechanism of resolving an IP address to a subscribtion does not work on a fixed-net Internet connection nor over WiFi.
+    This mechanism of utilizing the mobile connection does not work on a fixed-net Internet connection nor over WiFi or VPN.
     The API Consumer should not send a login_hint in the Authentication Request.
 
     # Resources and Operations overview

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -8,7 +8,7 @@ info:
 
     # Introduction
 
-    The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the API provider, returning "true" or "false", or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.
+    The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the API provider, returning "true" or "false", or by the application, by matching the phone number returned by the API Provider with the phone number of the device that is being used.
 
     It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither one-time passwords (OTP) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM is not spoofed or cloned.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -17,7 +17,7 @@ info:
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device.
     # API Functionality
 
-    This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service
+    This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service.
 
     # The Authentication Request
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -8,7 +8,7 @@ info:
 
     # Introduction
 
-    The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the network, returning "true" or false, or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.```
+    The Number Verification API is used by the API consumer to perform real-time checks to verify the phone number of a mobile device being used to access the application. This check can be done either by the API provider, returning "true" or "false", or by the application, by matching the phone number returned by the network with the phone number of the device that is being used.
 
     It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither one-time passwords (OTP) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM is not spoofed or cloned.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -72,6 +72,8 @@ info:
 
     In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
+    # Further info
+    [GSMA Mobile Connect Verified MSISDN specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.54-Mobile-Connect-Verified-MSISDN-Definition-and-Technical-Requirements-1.0.pdf) was used as source of input for this API.
   version: wip
   x-camara-commonalities: 0.5
   license:

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -2,43 +2,65 @@ openapi: 3.0.3
 info:
   title: Number Verification
   description: |
-    Service Enabling Network Function API to verify that the provided **mobile phone number** is the one used in the device. It verifies that the user is using a device with the same *mobile phone number* as it is declared.
-    It also makes it possible for a Service provider to verify the number itself by returning the phone number associated to the authenticated user's access token.
-
-    In this API **phone number** term refers to the mobile phone number.
+    API to verify or retrieve the **mobile phone number** that is currently used on the user's device
+  
+    In this API **phone number** refers to the mobile phone number.
 
     # Introduction
 
-    Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service, where the mobile device is accessing the *service provider* over a mobile network (WiFi connections are out of this API scope) either by getting the comparison result or receiving the phone number of the device that it is used, so they can verify it themselves.
+    Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service.
 
-    It uses direct mobile network connections to verify possession of a phone number in the background without requiring user interaction. There are neither OTPs (One-time passwords) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM (Subscriber Identity Module) is both actively connected to the mobile network and not spoofed or cloned.
-
+    The mobile phone number is personal data and end-user consent might be required.
 
     # Relevant Definitions and Concepts
 
-    - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection. Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
+    - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection. 
+    Network operators know to which subscriber a network resource is assigned at a given moment, for example the mobile phone number associated to a specific mobile network connection.
 
     # API Functionality
 
-    This enables a Service Provider (SP) to verify the phone number of the mobile device being used to access their service where the mobile device is accessing the *service provider* over a mobile network (WiFi connections are out of this API scope). This can happen either by getting the comparison result or receiving the phone number of the device that is used, so they can verify it themselves.
+    This API enables an API Consumer to verify or retrieve the phone number of the mobile device being used to access their service
+    
+    # The Authentication Request
 
+    If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi.
+    How the API Consumer gets a TS.43 temporary token is out-of-scope of the API definition.
+    When the API Consumer sends the Authentication Request, the temporary token is send in the login_hint parameter with the prefix "operatortoken:".
+
+    If the API Consumer does not have a TS.43 temporary token then the IP address of the mobile connection is used to identify the mobile subscription.
+    This mechanism of resolving an IP address to a subscribtion does not work on a fixed-net Internet connection nor over WiFi.
+    The API Consumer should not send a login_hint in the Authentication Request.
+    
     # Resources and Operations overview
-    This API currently provides two endpoints where both require a **3-legged token** and authentication via **mobile network** (**excluding** for example by SMS/OTP or user/password as an authentication method):
-    - The first one checks if the user mobile phone number matches the phone number associated with the mobile device. It can receive either a hashed or a plain text phone number as input and it compares the received input with the authenticated user's phone number associated to the access token in order to respond **true/false**.
-    - The next one retrieves the phone number associated to the user's token and returns it so the verification can be made by the service provider.
+    
+    This API currently provides two endpoints which both require a **3-legged token** and authentication via **mobile network** (**excluding** for example by SMS/OTP or user/password as an authentication method):
+    - The first one checks if the user's mobile phone number matches the phone number associated with the mobile device. 
+      It can receive either a hashed or a plain text phone number as input.
+      It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.
+    - The next one retrieves the phone number associated to the access token and returns it.
 
     # Sequence Diagram
-    Number Verification API uses the **standard [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)**. The following diagram will help to clarify the end-to-end process, including previous steps prior to this API call.
+    Number Verification API uses the **standard [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)**. 
+    The following diagram will help to clarify the end-to-end process, including steps prior to this API call.
 
-    Note that the diagram shows just an example of a direct integration from developer's application and MNO's authserver and API, other scenarios of indirect integration via Aggregator/Channel Partner should also be considered. Specific authorization flows may apply, as defined by e.g. GSMA Open Gateway (OGW).
+    Note that the diagram shows just an example of a direct integration from developer's application and the API Provider's Authorization Server and API.
 
     ![UML Sequence Diagram](https://raw.githubusercontent.com/camaraproject/NumberVerification/r2.2/documentation/API_documentation/assets/uml_v0.3.jpg)
 
-    **Additional details:**
+    **Implementation Details:**
 
-    - **(1):** Authentication must be automatic without any user interactions. Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App. So it is required to be authentication via mobile network and without the user being involved. the use of parameter prompt=none, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensures no user interaction.
+    - **(1):** Authentication must be automatic without any user interactions. 
+      Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App. 
+      
+      The API Consumer should use of the request parameter prompt=none in the Authication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
 
-    - **(2):** The way in which the phone_number is retrieved depends on the implementation. For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number. Some other implementations might request the phone_number associated to the token from Authserver.
+      The API Provider implies the request parameter prompt=none in the Authication Request for this API.
+
+      The lifetime of the access token SHOULD very short.
+      
+    - **(2):** The way in which the phone_number is retrieved depends on the implementation. 
+      For example, access token may be a self contained encrypted JWT, so API can decrypt and identify phone_number. 
+      Some other implementations might request the phone_number associated to the token from Authorization Server.
 
     # Authorization and authentication
 
@@ -50,8 +72,6 @@ info:
 
     In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
-    # Further info and support
-    [GSMA Mobile Connect Verified MSISDN specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.54-Mobile-Connect-Verified-MSISDN-Definition-and-Technical-Requirements-1.0.pdf) was used as source of input for this API.  For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
   version: 1.1.0-rc.2
   x-camara-commonalities: 0.5
   license:

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -10,6 +10,8 @@ info:
 
     Number Verification API performs real-time checks to verify the phone number of the mobile device being used to access a service provider (SP) service, either by getting the comparison result or receiving the phone number of the device that it is used, so they can verify it themselves.
 
+    It uses silent authentication (Network-based authentication or SIM-Based authentication) to verify possession of a phone number in the background without requiring user interaction. There are neither OTPs (One-time passwords) received by SMS nor authenticator app downloads, so it is much simpler. It can be used at sign up, login, or transaction time to validate that a user's SIM (Subscriber Identity Module) is not spoofed or cloned.
+
     # Relevant Definitions and Concepts
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the endpoint of a network connection.

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Number Verification
   description: |
-    API to verify or retrieve the **mobile phone number** that is currently used on the user's device
+    This API can verify or retrieve the **mobile phone number** that is currently allocated by the network operator to the SIM in the end user's device
 
     In this API **phone number** refers to the mobile phone number.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -54,7 +54,7 @@ info:
     - **(1):** Authentication must be automatic without any user interactions.
       Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
 
-      The API Consumer should use of the request parameter prompt=none in the Authentication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
+      The API Consumer should use the request parameter prompt=none in the Authentication Request, as described in **[OIDC Connect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)**, ensuring no user interaction.
 
       The API Provider implies the request parameter prompt=none in the Authentication Request for this API.
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -15,7 +15,7 @@ info:
     # Relevant Definitions and Concepts
 
     - **Network-Based Authentication**: Authentication mechanism based on the identification of the mobile phone.
-    A network operator knows to which subscriber a connected mobile phone belongs and what its associated phone number is. 
+    A network operator knows to which subscriber a connected mobile phone belongs and what its associated phone number is.
     - **SIM-Based Authentication**: Authentication mechanism based on the identification of the subscriber's SIM installed in the user's device. This mechanism relies on temporary tokens provided by the operator, as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
 
     # API Functionality

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -45,10 +45,7 @@ info:
 
     # Sequence Diagram
 
-    Number Verification API uses the **standard [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)**.
-    The following diagram will help to clarify the end-to-end process, including steps prior to this API call.
-
-    Note that the diagram shows just an example of a direct integration from developer's application and the API Provider's Authorization Server and API.
+    The following sequence diagram shows an example of a direct integration into the developer's application and the API Provider's Authorization Server and API for the case that no temporary token is available.
 
     ![UML Sequence Diagram](https://raw.githubusercontent.com/camaraproject/NumberVerification/r2.3/documentation/API_documentation/assets/uml_v0.3.jpg)
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -38,7 +38,7 @@ info:
 
     # Resources and Operations overview
 
-    This API currently provides two endpoints which both require a **3-legged token**:
+    This API currently provides two endpoints which both require a **3-legged token** obtained by using one of the two methods indicated in _The Authentication Request_ section (therefore **excluding** for example by SMS/OTP or user/password as an authentication method):
     - The /verify endpoint checks whether the mobile phone number registered by the user with the API consumer matches that actually associated with the mobile device.
       It can receive either a hashed or a plain text phone number as input.
       It compares the received phone number with the user's phone number associated to the access token in order to respond **true/false**.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature

#### What this PR does / why we need it:
Currently NumberVerification relies on network-based authentication, which means that the user's phone needs to be on a mobile connection because the phone's IP-address is mapped to subscriber's MSISDN.
This means that NumberVerification does not work over WiFI.

This PR does not change the NumberVerification API but changes how the API Consumer gets an access token for the API.

#### 
Fixes #86 #165 

#### Changelog input

```
 Enable NumberVerification for off-net scenarios e.g. if the user's device is connected to the Internet via WiFi.

```

#### Additional documentation 

GSMA TS.43 standard on temporary tokens and "operations"
https://www.gsma.com/get-involved/working-groups/gsma_resources/ts-43-v12-0-service-entitlement-configuration/


```
docs

```
