### PR TITLE
Support tempToken usage in AuthCodeFlow

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -27,7 +27,7 @@ info:
     ## Authentication Request with a temporary token
 
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.
-    The API Consumer sends the temporary token to their backend which sends a CIBA Authentication Request, as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
+    The API Consumer sends the temporary token to their backend which sends a CIBA Authentication Request, or uses the OpenId Connect Authorization Code Flow as described in the current release [CAMARA APIs Access and User Consent Management](https://github.com/camaraproject/IdentityAndConsentManagement), with a parameter "login_hint=operatortoken:<temporary token>".
     How the API Consumers get a TS.43 temporary token and how this token is sent to their backend, is out-of-scope of the API definition.
 
     ## Authentication Request without a temporary token


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
The documentation currently excludes being able to use the temp token (TS43) in the auth code flow. NV users should be able to use either temp token or network based auth with the same flow, if they choose.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes 

#### Special notes for reviewers:

Related #181 , https://github.com/camaraproject/IdentityAndConsentManagement/pull/290

#### Changelog input

```
 release-note documentation: allow temptoken usage in auth code flow

```

#### Additional documentation 



```
docs

```
