### PR TITLE
Add pattern validation for hashedPhoneNumber

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -196,6 +196,7 @@ components:
         hashedPhoneNumber:
           description: Hashed phone number. SHA-256 (in hexadecimal representation) of the mobile phone number in **E.164 format (starting with country code)**. Prefixed with '+'.
           type: string
+          pattern: '^[a-fA-F0-9]{64}$'
           example: 32f67ab4e4312618b09cd23ed8ce41b13e095fe52b73b2e8da8ef49830e50dba
     NumberVerificationMatchResponse:
       type: object


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:

This PR introduces pattern validation for the hashedPhoneNumber parameter.

Previously, pattern validation was only applied to the phoneNumber field, ensuring it followed the E.164 format (i.e., starting with the country code and prefixed with +). However, when a user provides a hashedPhoneNumber, we cannot reverse it to verify the presence of the + prefix due to the nature of hashing.

To address this, we now enforce a pattern validation specifically for hashedPhoneNumber. The validation checks that the hash:

- Is exactly 64 characters long,
- Contains only valid hexadecimal characters (i.e., a-f, A-F, 0-9).

This approach ensures that the input format for hashedPhoneNumber remains consistent and secure, without relying on characteristics of the unhashed value.

#### Which issue(s) this PR fixes:
Fixes #189 

#### Special notes for reviewers:
No functional change.

#### Changelog input
Add pattern validation for hashedPhoneNumber

