### PR TITLE
Access token security considerations for Number Verification API

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -28,8 +28,8 @@ info:
     Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
 
     **Authentication is the core of this service API, ensuring that the phone number retrieved or verified is correct and according to the current SIM or network connection.** For that purpose, the following security requirements apply to access tokens containing number verification scopes:
- 
-    - Single-use token (one-time use): To prevent replay attacks and ensure the integrity of the verification process, the access token MUST be restricted to a single successful API call. 
+
+    - Single-use token (one-time use): To prevent replay attacks and ensure the integrity of the verification process, the access token MUST be restricted to a single successful API call.
     - No refresh tokens: Refresh tokens MUST not be issued for Number Verification scopes. If the token expires or is used up, the API Consumer MUST initiate a new authorization flow to obtain a new access token.
     - Short-lived expiration: The access token MUST not exceed an expiration time of 300 seconds (5 minutes).
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -29,7 +29,7 @@ info:
 
     **Authentication is the core of this service API, ensuring that the phone number retrieved or verified is correct and according to the current SIM or network connection.** For that purpose, the following security requirements apply to access tokens containing number verification scopes:
 
-    - Single-use token (one-time use): To prevent replay attacks and ensure the integrity of the verification process, the access token MUST be restricted to a single successful API call.
+    - Single-use token (one-time use): To prevent replay attacks and ensure the integrity of the verification process, the access token MUST be restricted to a single API call.
     - No refresh tokens: Refresh tokens MUST not be issued for Number Verification scopes. If the token expires or is used up, the API Consumer MUST initiate a new authorization flow to obtain a new access token.
     - Short-lived expiration: The access token MUST not exceed an expiration time of 300 seconds (5 minutes).
 

--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -27,6 +27,12 @@ info:
     **For NumberVerification the API provider guarantees that there is no user interaction.** Would user interaction be needed the authorization server returns an error.
     Authentication methods such as SMS OTP or user/password are incompatible, as the goal is to validate the mobile phone number that is accessing the App.
 
+    **Authentication is the core of this service API, ensuring that the phone number retrieved or verified is correct and according to the current SIM or network connection.** For that purpose, the following security requirements apply to access tokens containing number verification scopes:
+ 
+    - Single-use token (one-time use): To prevent replay attacks and ensure the integrity of the verification process, the access token MUST be restricted to a single successful API call. 
+    - No refresh tokens: Refresh tokens MUST not be issued for Number Verification scopes. If the token expires or is used up, the API Consumer MUST initiate a new authorization flow to obtain a new access token.
+    - Short-lived expiration: The access token MUST not exceed an expiration time of 300 seconds (5 minutes).
+
     ## Authentication Request with a temporary token
 
     If the API Consumer has a TS.43 temporary token created on the mobile device then this API works over all connections e.g. WiFi taking advantage of the SIM-Based authentication.


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This pull request updates the documentation for the Number Verification API to clarify and strengthen its authentication requirements. The main focus is on enhancing security by specifying stricter rules for access tokens used in the verification process.

**Authentication and Security Enhancements:**

* Added explicit requirements that access tokens for number verification must be single-use, preventing replay attacks and ensuring each token is valid for only one API call.
* Stated that refresh tokens must not be issued for number verification scopes; a new authorization flow is required for each new access token.
* Limited the maximum expiration time for access tokens to 300 seconds (5 minutes) to reduce the risk window for token misuse.

#### Which issue(s) this PR fixes:

Fixes #154 

#### Special notes for reviewers:

N/A

#### Changelog input

```
 access token security requirements
```

#### Additional documentation 

N/A