### PR TITLE
Correct externalDocs.description wording in number-verification.yaml

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -92,7 +92,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 externalDocs:
-  description: Project documentation at CAMARA
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/NumberVerification
 servers:
   - url: '{apiRoot}/number-verification/vwip'


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

`externalDocs.description` in `number-verification.yaml` read "Project documentation at CAMARA" instead of "Product documentation at CAMARA" (Design Guide §5.4).

#### Which issue(s) this PR fixes:

None

#### Special notes for reviewers:

One-line fix, no behavior change.

#### Changelog input

```
release-note
Fix externalDocs.description wording in number-verification.yaml.
```

#### Additional documentation

This section can be blank.

```
docs

```
