### PR TITLE
fix(number-verification): re-sync additional-error-responses description and bump commonalities to 0.9.0

### DIFF
--- a/code/API_definitions/number-verification.yaml
+++ b/code/API_definitions/number-verification.yaml
@@ -70,12 +70,13 @@ info:
 
       In the case of the Number Verification API scenario and according to the API definition, 3-legged access tokens must be used by API clients to invoke this API with dedicated scope. The API client must authenticate on behalf of a specific user to use this service. This must be done via mobile network authentication.
 
-     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
-    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified from the `x-camara-commonalities` field, the changelog and the metadata of the released API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
     <!-- CAMARA:MANDATORY:additional-error-responses:END -->
@@ -87,7 +88,7 @@ info:
     <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: 0.9.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

The `additional-error-responses` `info.description` block in `number-verification.yaml` had drifted from the canonical `CAMARA:MANDATORY` template: paragraph 3 still referenced the retired `API Readiness Checklist` document instead of the `x-camara-commonalities` field, changelog, and API metadata. This re-copies the current BEGIN..END block from the Commonalities template and bumps `x-camara-commonalities` to `0.9.0` to match.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note
Fix drifted additional-error-responses description and bump x-camara-commonalities to 0.9.0.
```

#### Additional documentation 

This section can be blank.



```
docs

```
