### PR TITLE
fix(number-verification): correct Gherkin test definition defects

### DIFF
--- a/code/Test_definitions/number-verification-phoneNumberShare.feature
+++ b/code/Test_definitions/number-verification-phoneNumberShare.feature
@@ -36,7 +36,7 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberShare
 
   # Generic 401 errors
 
-  @phone_number_verify_401.1_no_authorization_header
+  @phone_number_share_401.1_no_authorization_header
   Scenario: No Authorization header
     Given the header "Authorization" is removed
     When the request "phoneNumberShare" is sent
@@ -45,7 +45,7 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberShare
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @phone_number_verify_401.2_expired_access_token
+  @phone_number_share_401.2_expired_access_token
   Scenario: Expired access token
     Given the header "Authorization" is set to an expired access token
     When the request "phoneNumberShare" is sent
@@ -54,7 +54,7 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberShare
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @phone_number_verify_401.3_invalid_access_token
+  @phone_number_share_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token
     When the request "phoneNumberShare" is sent

--- a/code/Test_definitions/number-verification-phoneNumberVerify.feature
+++ b/code/Test_definitions/number-verification-phoneNumberVerify.feature
@@ -89,7 +89,8 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberVerify
   Scenario: Error when request body contains a property but it is neither phoneNumber nor hashedPhoneNumber
     Given a valid testing phoneNumber supported by the service, identified by the token
     And the request body property "$.additional_property" is set to "foo_value"
-    And the request body does not contain neither "$.phoneNumber" nor "$.hashedPhoneNumber"
+    And the request body contains neither "$.phoneNumber" nor "$.hashedPhoneNumber"
+    When the request "phoneNumberVerify" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
@@ -100,8 +101,7 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberVerify
   @phone_number_verify_400.4_both_phone_number_and_hashed_in_request
   Scenario: Response error when phoneNumber and hashedPhoneNumber are provided together in the request body
     Given the request body property "$.phoneNumber" is set to a valid phone number
-    And the same phone number is compliant with OAS schema at "#/components/schemas/PhoneNumber"
-    And the request body property "$.hashedPhoneNumber" is set to a valid phone number compliant with OAS schema at "#/components/schemas/HashedPhoneNumber"
+    And the request body property "$.hashedPhoneNumber" is set to a valid phone number, hashed in SHA-256 (in hexadecimal representation)
     When the request "phoneNumberVerify" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
@@ -169,7 +169,7 @@ Feature: CAMARA Number Verification API, vwip - Operation phoneNumberVerify
   @phone_number_verify_C02.01_phone_number_not_schema_compliant
   Scenario: Phone number value does not comply with the schema
     Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-    And the request body property "$.phoneNumber" does not comply with the OAS schema at "#/components/schemas/PhoneNumber"
+    And the request body property "$.phoneNumber" is set to a value that does not comply with the schema of the "phoneNumber" property at "#/components/schemas/NumberVerificationRequestBody"
     When the request "phoneNumberVerify" is sent
     Then the response status code is 400
     And the response property "$.status" is 400


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Fixes three defects in the Gherkin test definitions under `code/Test_definitions/`: scenario `400.3` never sends its request (missing `When` step) and has a double-negative in its wording; scenarios `400.4` and `C02.01` reference schema anchors (`PhoneNumber`, `HashedPhoneNumber`) that don't exist in `number-verification.yaml`; and the three 401 scenarios in `number-verification-phoneNumberShare.feature` carry copy-pasted `phone_number_verify` tags instead of `phone_number_share`. Both files parse cleanly with the official `@cucumber/gherkin` parser after the change, and every scenario now contains an action step.

#### Which issue(s) this PR fixes:

Fixes #254

#### Special notes for reviewers:

Not changed in this PR, but worth a maintainer's eye: the `Given` of `@phone_number_verify_C02.01` ("a valid access token which does not identify a single phone number") reads as copied from device-identifier API templates. For Number Verification a 3-legged token always identifies the subscriber's phone number, so this precondition looks unsatisfiable as written. Happy to follow up with a separate issue/PR if you agree.

#### Changelog input

```
release-note
Fix test definitions: add missing When step in scenario 400.3 of phoneNumberVerify, replace references to non-existent schemas (PhoneNumber, HashedPhoneNumber), and correct copy-pasted scenario tags in the phoneNumberShare feature file.
```

#### Additional documentation

This section can be blank.

```
docs

```
